### PR TITLE
Replace PUT upload with POST to be able to transmit more than 20'000'000 characters

### DIFF
--- a/UploadBOM/src/dtrackClient.js
+++ b/UploadBOM/src/dtrackClient.js
@@ -19,7 +19,7 @@ class DTrackClient {
       request('/api/v1/bom', {
         ...this.baseOptions,
         method: 'POST',
-        body: {
+        formData: {
           "project": projId,
           "bom": bom.toString()
         }

--- a/UploadBOM/src/dtrackClient.js
+++ b/UploadBOM/src/dtrackClient.js
@@ -18,10 +18,10 @@ class DTrackClient {
     return new Promise((resolve, reject) => {
       request('/api/v1/bom', {
         ...this.baseOptions,
-        method: 'PUT',
+        method: 'POST',
         body: {
           "project": projId,
-          "bom": bom.toString('base64')
+          "bom": bom.toString()
         }
       },
         (error, response) => {
@@ -38,12 +38,12 @@ class DTrackClient {
     return new Promise((resolve, reject) => {
       request('/api/v1/bom', {
         ...this.baseOptions,
-        method: 'PUT',
-        body: {
-          "autoCreate": true,
+        method: 'POST',
+        formData: {
+          "autoCreate": 'true',
           "projectName": name,
           "projectVersion": version,
-          "bom": bom.toString('base64')
+          "bom": bom.toString()
         }
       },
         (error, response) => {


### PR DESCRIPTION
The currently used upload action used the `PUT` method which has a limit of [20'000'000 characters](https://github.com/nscuro/dependency-track/blob/43e73d9bc8feeaa4dcf7774194900f04f759b539/src/main/java/org/dependencytrack/resources/v1/BomResource.java#L262). 

Dependency Track provides the same upload function when using the [`POST` method](https://docs.dependencytrack.org/usage/cicd/). Example from Dependency Track for cURL:

```bash
curl -X "POST" "http://dtrack.example.com/api/v1/bom" \
     -H 'Content-Type: multipart/form-data' \
     -H 'X-Api-Key: LPojpCDSsEd4V9Zi6qCWr4KsiF3Konze' \
     -F "project=f90934f5-cb88-47ce-81cb-db06fc67d4b4" \
     -F "bom=<?xml version=\"1.0\" encoding=\"UTF-8\"?>..."
```

I did not test the upload directly with the extension, instead I wrote a simple node script which has the client code inside, which worked fine for me. For the test I used Dependency Track v4.11.7.

```js
const request = require('request');
const fs = require('fs');

function test()
{
    const fileContent = fs.readFileSync('sbom.json');
    request('/api/v1/bom', {
        baseUrl: 'https://redacted/dtrack,
        method: 'POST',
        headers: {
            'X-API-Key': '...'
        },
        formData: {
            "autoCreate": "true",
            "projectName": "temp",
            "projectVersion": "1.0.0",
            "bom": fileContent.toString()
        }
    }, function (error, response, body) {
        if (error) {
          console.error('Error:', error);
        } else {
          console.log('Response Status Code:', response.statusCode);
          console.log('Response Body:', body);
        }
      });
}

test();
```

I did not find any reason why not to use only the `POST` method, but if there is any reason, we could call it only when we are exceeding the character limit.

Fixes #6 